### PR TITLE
Less unuseful badness errors (underfull and overfull error)

### DIFF
--- a/ingi1123.sty
+++ b/ingi1123.sty
@@ -232,4 +232,8 @@ version={4.0},
 \newtheorem{myhyp}{Hypothèse}[chapter]
 \newtheorem{mythese}[mydef]{Thèse}
 
+% Debug warnings - à commenter si on veut tout vérifier
+\overfullrule=100pt
+\hbadness=10000
+
 \endinput

--- a/ingi1123.sty
+++ b/ingi1123.sty
@@ -233,7 +233,7 @@ version={4.0},
 \newtheorem{mythese}[mydef]{Thèse}
 
 % Debug warnings - à commenter si on veut tout vérifier
-\overfullrule=100pt
+%\overfullrule=100pt % Semble ne pas marcher ici
 \hbadness=10000
 
 \endinput


### PR DESCRIPTION
Une simple règle pour enlever des logs d'erreurs classique